### PR TITLE
Fixed error when removing slash at the end of the channel name on ChannelPromoList

### DIFF
--- a/opps/promos/views.py
+++ b/opps/promos/views.py
@@ -52,7 +52,7 @@ class ChannelPromoList(ListView):
     @property
     def queryset(self):
         site = get_current_site(self.request)
-        long_slug = self.kwargs['channel__long_slug'][:-1]
+        long_slug = self.kwargs['channel__long_slug'].strip('/')
         get_object_or_404(Channel, long_slug=long_slug)
         return Promo.objects.filter(
             channel__long_slug=long_slug,


### PR DESCRIPTION
This error occurs when using a specific URL where the channel name is not the final text of the url.

E.g. / site /$channel-slug/promos
